### PR TITLE
Format code

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -5,10 +5,10 @@ use unicorn::{Cpu, CpuARM};
 fn main() {
     let (major, minor) = unicorn::unicorn_version();
     println!("version : {}.{}", major, minor);
-    println!("Support for:\n\t x86: {}\n\t arm: {}\n\t mips: {}", 
-            unicorn::arch_supported(unicorn::Arch::X86),
-            unicorn::arch_supported(unicorn::Arch::ARM),
-            unicorn::arch_supported(unicorn::Arch::MIPS));
+    println!("Support for:\n\t x86: {}\n\t arm: {}\n\t mips: {}",
+             unicorn::arch_supported(unicorn::Arch::X86),
+             unicorn::arch_supported(unicorn::Arch::ARM),
+             unicorn::arch_supported(unicorn::Arch::MIPS));
 
     let emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to create emulator");
 
@@ -18,9 +18,9 @@ fn main() {
     println!("hardware mode : {}", hardware_mode);
 
     println!("Sample error message : {}", unicorn::Error::HOOK.msg());
-    
-    emu.mem_map(0x10000, 0x4000, unicorn::PROT_ALL).expect("failed to map first memory region"); 
-    emu.mem_map(0x20000, 0x4000, unicorn::PROT_ALL).expect("failed to map second memory region"); 
+
+    emu.mem_map(0x10000, 0x4000, unicorn::PROT_ALL).expect("failed to map first memory region");
+    emu.mem_map(0x20000, 0x4000, unicorn::PROT_ALL).expect("failed to map second memory region");
     let regions = emu.mem_regions().expect("failed to retrieve memory mappings");
     println!("Regions : {}", regions.len());
 
@@ -28,4 +28,3 @@ fn main() {
         println!("{:?}", region);
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 //!    let x86_code32 : Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 //!
 //!    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-//!    emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL); 
-//!    emu.mem_write(0x1000, &x86_code32); 
+//!    emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL);
+//!    emu.mem_write(0x1000, &x86_code32);
 //!    emu.reg_write_i32(unicorn::RegisterX86::ECX, -10);
 //!    emu.reg_write_i32(unicorn::RegisterX86::EDX, -50);
 //!
@@ -23,7 +23,7 @@
 //!    assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::EDX), Ok((-51)));
 //! }
 //! ```
-//! 
+//!
 extern crate libc;
 #[macro_use]
 extern crate bitflags;
@@ -182,13 +182,12 @@ pub trait Cpu {
                      callback: extern "C" fn(engine: uc_handle,
                                              address: u64,
                                              size: u32,
-                                             user_data: *mut u64)
-                                            )
+                                             user_data: *mut u64))
                      -> Result<uc_hook, Error> {
         self.emu().add_code_hook(hook_type, begin, end, callback)
     }
 
-    /// Add a memory hook. 
+    /// Add a memory hook.
     fn add_mem_hook(&self,
                     hook_type: HookType,
                     begin: u64,
@@ -198,8 +197,7 @@ pub trait Cpu {
                                             address: u64,
                                             size: i32,
                                             value: i64,
-                                            user_data: *mut u64)
-                                           )
+                                            user_data: *mut u64))
                     -> Result<uc_hook, Error> {
         self.emu().add_mem_hook(hook_type, begin, end, callback)
     }
@@ -578,9 +576,8 @@ impl Unicorn {
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
     pub fn mem_protect(&self, address: u64, size: usize, perms: Protection) -> Result<(), Error> {
-        let err = unsafe {
-            uc_mem_protect(self.handle, address, size as libc::size_t, perms.bits())
-        };
+        let err =
+            unsafe { uc_mem_protect(self.handle, address, size as libc::size_t, perms.bits()) };
         if err == Error::OK {
             Ok(())
         } else {
@@ -627,9 +624,8 @@ impl Unicorn {
                      timeout: u64,
                      count: usize)
                      -> Result<(), Error> {
-        let err = unsafe {
-            uc_emu_start(self.handle, begin, until, timeout, count as libc::size_t)
-        };
+        let err =
+            unsafe { uc_emu_start(self.handle, begin, until, timeout, count as libc::size_t) };
         if err == Error::OK {
             Ok(())
         } else {
@@ -658,8 +654,7 @@ impl Unicorn {
                          callback: extern "C" fn(engine: uc_handle,
                                                  address: u64,
                                                  size: u32,
-                                                 user_data: *mut u64)
-                                                )
+                                                 user_data: *mut u64))
                          -> Result<uc_hook, Error> {
         let mut hook: libc::size_t = 0;
         let mut user_data: libc::size_t = 0;
@@ -682,7 +677,7 @@ impl Unicorn {
         }
     }
 
-    /// Add a memory hook. 
+    /// Add a memory hook.
     pub fn add_mem_hook(&self,
                         hook_type: HookType,
                         begin: u64,
@@ -692,8 +687,7 @@ impl Unicorn {
                                                 address: u64,
                                                 size: i32,
                                                 value: i64,
-                                                user_data: *mut u64)
-                                               )
+                                                user_data: *mut u64))
                         -> Result<uc_hook, Error> {
         let mut hook: libc::size_t = 0;
         let mut user_data: libc::size_t = 0;

--- a/src/unicorn_const.rs
+++ b/src/unicorn_const.rs
@@ -5,19 +5,19 @@ pub const MILISECOND_SCALE: u64 = 1000;
 #[repr(C)]
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Arch {
-    /// ARM architecture (including Thumb, Thumb-2) 
+    /// ARM architecture (including Thumb, Thumb-2)
     ARM = 1,
-    /// ARM-64, also called AArch64 
+    /// ARM-64, also called AArch64
     ARM64,
-    /// MIPS architecture 
+    /// MIPS architecture
     MIPS,
-    /// X86 architecture (including x86 & x86-64) 
+    /// X86 architecture (including x86 & x86-64)
     X86,
-    /// PowerPC architecture 
+    /// PowerPC architecture
     PPC,
-    /// Sparc architecture 
+    /// Sparc architecture
     SPARC,
-    /// M68K architecture 
+    /// M68K architecture
     M68K,
 }
 

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -4,23 +4,29 @@ use unicorn::{Cpu, CpuX86, CpuARM, CpuMIPS, uc_handle};
 
 #[test]
 fn emulate_x86() {
-    let x86_code32 : Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
-    
+    let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
+
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(emu.reg_write(unicorn::RegisterX86::EAX, 123), Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterX86::EAX), Ok((123)));
-    
+
     // Attempt to write to memory before mapping it.
-    assert_eq!(emu.mem_write(0x1000, &x86_code32), (Err(unicorn::Error::WRITE_UNMAPPED))); 
-    
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(())); 
-    assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(())); 
-    assert_eq!(emu.mem_read(0x1000, x86_code32.len()), Ok(x86_code32.clone()));  
-    
+    assert_eq!(emu.mem_write(0x1000, &x86_code32),
+               (Err(unicorn::Error::WRITE_UNMAPPED)));
+
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
+    assert_eq!(emu.mem_read(0x1000, x86_code32.len()),
+               Ok(x86_code32.clone()));
+
     assert_eq!(emu.reg_write(unicorn::RegisterX86::ECX, 10), Ok(()));
     assert_eq!(emu.reg_write(unicorn::RegisterX86::EDX, 50), Ok(()));
-    
-    assert_eq!(emu.emu_start(0x1000, (0x1000 + x86_code32.len()) as u64, 10 * unicorn::SECOND_SCALE, 1000), Ok(()));
+
+    assert_eq!(emu.emu_start(0x1000,
+                             (0x1000 + x86_code32.len()) as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterX86::ECX), Ok((11)));
     assert_eq!(emu.reg_read(unicorn::RegisterX86::EDX), Ok((49)));
 }
@@ -29,17 +35,21 @@ fn emulate_x86() {
 
 #[test]
 fn emulate_x86_negative_values() {
-    let x86_code32 : Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
-    
+    let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
+
     let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(())); 
-    assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(())); 
-    
+
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
+
     assert_eq!(emu.reg_write_i32(unicorn::RegisterX86::ECX, -10), Ok(()));
     assert_eq!(emu.reg_write_i32(unicorn::RegisterX86::EDX, -50), Ok(()));
-    
-    assert_eq!(emu.emu_start(0x1000, (0x1000 + x86_code32.len()) as u64, 10 * unicorn::SECOND_SCALE, 1000), Ok(()));
+
+    assert_eq!(emu.emu_start(0x1000,
+                             (0x1000 + x86_code32.len()) as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
     assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::ECX), Ok((-9)));
     assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::EDX), Ok((-51)));
 }
@@ -47,18 +57,20 @@ fn emulate_x86_negative_values() {
 #[test]
 fn x86_code_callback() {
     #[allow(unused_variables)]
-    extern fn callback(engine : uc_handle, address : u64, size : u32, user_data : *mut u64) {
+    extern "C" fn callback(engine: uc_handle, address: u64, size: u32, user_data: *mut u64) {
         println!("in callback at 0x{:08x}!", address);
     }
-    
-    let x86_code32 : Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
-    
+
+    let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
+
     let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(())); 
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
-    
-    let hook = emu.add_code_hook(unicorn::HookType::BLOCK, 0x1000, 0x2000, callback).expect("failed to add code hook");
-    assert_eq!(emu.emu_start(0x1000, 0x1001, 10 * unicorn::SECOND_SCALE, 1000), Ok(()));
+
+    let hook = emu.add_code_hook(unicorn::HookType::BLOCK, 0x1000, 0x2000, callback)
+        .expect("failed to add code hook");
+    assert_eq!(emu.emu_start(0x1000, 0x1001, 10 * unicorn::SECOND_SCALE, 1000),
+               Ok(()));
     assert_eq!(emu.remove_hook(hook), Ok(()));
 
 }
@@ -66,61 +78,82 @@ fn x86_code_callback() {
 #[test]
 fn x86_mem_callback() {
     #[allow(unused_variables)]
-    extern fn callback(engine : uc_handle, mem_type : unicorn::MemType, address : u64, size : i32, value : i64, user_data : *mut u64) {
+    extern "C" fn callback(engine: uc_handle,
+                           mem_type: unicorn::MemType,
+                           address: u64,
+                           size: i32,
+                           value: i64,
+                           user_data: *mut u64) {
         println!("unmapped mem read at 0x{:08x}!", address);
     }
-    
-    let x86_code32 : Vec<u8> = vec![0x8b, 0x00]; // MOV eax, dword [eax]
-    
+
+    let x86_code32: Vec<u8> = vec![0x8b, 0x00]; // MOV eax, dword [eax]
+
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(())); 
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
-    
-    let hook = emu.add_mem_hook(unicorn::HookType::MEM_READ_UNMAPPED, 0, std::u64::MAX, callback).expect("failed to add memory hook");
+
+    let hook = emu.add_mem_hook(unicorn::HookType::MEM_READ_UNMAPPED,
+                      0,
+                      std::u64::MAX,
+                      callback)
+        .expect("failed to add memory hook");
     assert_eq!(emu.reg_write(unicorn::RegisterX86::EAX, 0x123), Ok(()));
-    assert_eq!(emu.emu_start(0x1000, 0x1001, 10 * unicorn::SECOND_SCALE, 1), Err((unicorn::Error::READ_UNMAPPED)));
+    assert_eq!(emu.emu_start(0x1000, 0x1001, 10 * unicorn::SECOND_SCALE, 1),
+               Err((unicorn::Error::READ_UNMAPPED)));
     assert_eq!(emu.remove_hook(hook), Ok(()));
 }
 
 #[test]
 fn emulate_arm() {
-    let arm_code32 : Vec<u8> = vec![0x83, 0xb0]; // sub    sp, #0xc 
+    let arm_code32: Vec<u8> = vec![0x83, 0xb0]; // sub    sp, #0xc
 
     let mut emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to instantiate emulator");
     assert_eq!(emu.reg_write(unicorn::RegisterARM::R1, 123), Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterARM::R1), Ok((123)));
 
     // Attempt to write to memory before mapping it.
-    assert_eq!(emu.mem_write(0x1000, &arm_code32), (Err(unicorn::Error::WRITE_UNMAPPED)));
+    assert_eq!(emu.mem_write(0x1000, &arm_code32),
+               (Err(unicorn::Error::WRITE_UNMAPPED)));
 
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &arm_code32), Ok(()));
-    assert_eq!(emu.mem_read(0x1000, arm_code32.len()), Ok(arm_code32.clone()));
+    assert_eq!(emu.mem_read(0x1000, arm_code32.len()),
+               Ok(arm_code32.clone()));
 
     assert_eq!(emu.reg_write(unicorn::RegisterARM::SP, 12), Ok(()));
     assert_eq!(emu.reg_write(unicorn::RegisterARM::R0, 10), Ok(()));
 
-    assert_eq!(emu.emu_start(0x1000, (0x1000 + arm_code32.len()) as u64, 10 * unicorn::SECOND_SCALE, 1000), Ok(()));
+    assert_eq!(emu.emu_start(0x1000,
+                             (0x1000 + arm_code32.len()) as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterARM::SP), Ok((0)));
     assert_eq!(emu.reg_read(unicorn::RegisterARM::R0), Ok((10)));
 }
 
-#[test] 
+#[test]
 fn emulate_mips() {
     let mips_code32 = vec![0x56, 0x34, 0x21, 0x34]; // ori $at, $at, 0x3456;
-    
+
     let mut emu = CpuMIPS::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(())); 
-    assert_eq!(emu.mem_write(0x1000, &mips_code32), Ok(())); 
-    assert_eq!(emu.mem_read(0x1000, mips_code32.len()), Ok(mips_code32.clone()));  
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_write(0x1000, &mips_code32), Ok(()));
+    assert_eq!(emu.mem_read(0x1000, mips_code32.len()),
+               Ok(mips_code32.clone()));
     assert_eq!(emu.reg_write(unicorn::RegisterMIPS::AT, 0), Ok(()));
-    assert_eq!(emu.emu_start(0x1000, (0x1000 + mips_code32.len()) as u64, 10 * unicorn::SECOND_SCALE, 1000), Ok(()));
+    assert_eq!(emu.emu_start(0x1000,
+                             (0x1000 + mips_code32.len()) as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterMIPS::AT), Ok((0x3456)));
 }
 
 #[test]
 fn mem_unmapping() {
     let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(())); 
-    assert_eq!(emu.mem_unmap(0x1000, 0x4000), Ok(())); 
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_unmap(0x1000, 0x4000), Ok(()));
 }


### PR DESCRIPTION
Format all code with `rustfmt`. Should now follows the Rust guideline. Make it easier for my following PR (All of them formatted code on save).