### PR TITLE
Refactor hook API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,7 +828,10 @@ impl Unicorn {
     /// `hook` is the value returned by either `add_code_hook` or `add_mem_hook`.
     pub fn remove_hook(&mut self, hook: uc_hook) -> Result<(), Error> {
         let err = unsafe { uc_hook_del(self.handle, hook) } as Error;
+        // Check in all map to find which one has the hook.
         self.code_callbacks.remove(&hook);
+        self.intr_callbacks.remove(&hook);
+        self.mem_callbacks.remove(&hook);
         if err == Error::OK {
             Ok(())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod x86_const;
 
 use ffi::*;
 use std::mem;
+use std::collections::HashMap;
 use std::ffi::CStr;
 
 pub use arm64_const::*;
@@ -96,6 +97,8 @@ pub trait Cpu {
     type Reg: Register;
 
     fn emu(&self) -> &Unicorn;
+
+    fn mut_emu<'a>(&'a mut self) -> &'a mut Unicorn;
 
     /// Read an unsigned value from a register.
     fn reg_read(&self, reg: Self::Reg) -> Result<u64, Error> {
@@ -175,16 +178,22 @@ pub trait Cpu {
     }
 
     /// Add a code hook.
-    fn add_code_hook(&self,
-                     hook_type: HookType,
-                     begin: u64,
-                     end: u64,
-                     callback: extern "C" fn(engine: uc_handle,
-                                             address: u64,
-                                             size: u32,
-                                             user_data: *mut u64))
-                     -> Result<uc_hook, Error> {
-        self.emu().add_code_hook(hook_type, begin, end, callback)
+    fn add_code_hook<F>(&mut self,
+                        hook_type: CodeHookType,
+                        begin: u64,
+                        end: u64,
+                        callback: F)
+                        -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u64, u32) -> () + 'static
+    {
+        self.mut_emu().add_code_hook(hook_type, begin, end, callback)
+    }
+
+    /// Add an interrupt hook.
+    fn add_intr_hook<F>(&mut self, begin: u64, end: u64, callback: F) -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u32) + 'static
+    {
+        self.mut_emu().add_intr_hook(begin, end, callback)
     }
 
     /// Add a memory hook.
@@ -205,8 +214,8 @@ pub trait Cpu {
     /// Remove a hook.
     ///
     /// `hook` is the value returned by either `add_code_hook` or `add_mem_hook`.
-    fn remove_hook(&self, hook: uc_hook) -> Result<(), Error> {
-        self.emu().remove_hook(hook)
+    fn remove_hook(&mut self, hook: uc_hook) -> Result<(), Error> {
+        self.mut_emu().remove_hook(hook)
     }
 
     /// Return the last error code when an API function failed.
@@ -249,6 +258,10 @@ impl Cpu for CpuARM {
     fn emu(&self) -> &Unicorn {
         &self.emu
     }
+
+    fn mut_emu(&mut self) -> &mut Unicorn {
+        &mut self.emu
+    }
 }
 
 /// An ARM64 emulator instance.
@@ -272,6 +285,10 @@ impl Cpu for CpuARM64 {
 
     fn emu(&self) -> &Unicorn {
         &self.emu
+    }
+
+    fn mut_emu(&mut self) -> &mut Unicorn {
+        &mut self.emu
     }
 }
 
@@ -297,6 +314,10 @@ impl Cpu for CpuM68K {
     fn emu(&self) -> &Unicorn {
         &self.emu
     }
+
+    fn mut_emu(&mut self) -> &mut Unicorn {
+        &mut self.emu
+    }
 }
 
 /// A MIPS emulator instance.
@@ -320,6 +341,10 @@ impl Cpu for CpuMIPS {
 
     fn emu(&self) -> &Unicorn {
         &self.emu
+    }
+
+    fn mut_emu(&mut self) -> &mut Unicorn {
+        &mut self.emu
     }
 }
 
@@ -345,6 +370,10 @@ impl Cpu for CpuSPARC {
     fn emu(&self) -> &Unicorn {
         &self.emu
     }
+
+    fn mut_emu(&mut self) -> &mut Unicorn {
+        &mut self.emu
+    }
 }
 
 /// An X86 emulator instance.
@@ -369,18 +398,42 @@ impl Cpu for CpuX86 {
     fn emu(&self) -> &Unicorn {
         &self.emu
     }
-}
 
-
-/// Internal : A Unicorn emulator instance, use one of the Cpu structs instead.
-pub struct Unicorn {
-    handle: libc::size_t, // Opaque handle to uc_engine
+    fn mut_emu(&mut self) -> &mut Unicorn {
+        &mut self.emu
+    }
 }
 
 #[allow(non_camel_case_types)]
 pub type uc_handle = libc::size_t;
 #[allow(non_camel_case_types)]
 pub type uc_hook = libc::size_t;
+
+/// Struct to bind a unicorn instance to a callback.
+pub struct UnicornHook<F> {
+    unicorn: *const Unicorn,
+    callback: F,
+}
+
+extern "C" fn code_hook_proxy(_: uc_handle, address: u64, size: u32, user_data: *mut CodeHook) {
+    let code_hook = unsafe { &mut *user_data };
+    (code_hook.callback)(unsafe { &*code_hook.unicorn }, address, size);
+}
+
+extern "C" fn intr_hook_proxy(_: uc_handle, intno: u32, user_data: *mut IntrHook) {
+    let intr_hook = unsafe { &mut *user_data };
+    (intr_hook.callback)(unsafe { &*intr_hook.unicorn }, intno);
+}
+
+type CodeHook = UnicornHook<Box<Fn(&Unicorn, u64, u32)>>;
+type IntrHook = UnicornHook<Box<Fn(&Unicorn, u32)>>;
+
+/// Internal : A Unicorn emulator instance, use one of the Cpu structs instead.
+pub struct Unicorn {
+    handle: libc::size_t, // Opaque handle to uc_engine
+    code_callbacks: HashMap<uc_hook, Box<CodeHook>>,
+    intr_callbacks: HashMap<uc_hook, Box<IntrHook>>,
+}
 
 impl Error {
     pub fn msg(&self) -> String {
@@ -428,7 +481,11 @@ impl Unicorn {
         let mut handle: libc::size_t = 0;
         let err = unsafe { uc_open(arch, mode, &mut handle) };
         if err == Error::OK {
-            Ok(Unicorn { handle: handle })
+            Ok(Unicorn {
+                handle: handle,
+                code_callbacks: HashMap::default(),
+                intr_callbacks: HashMap::default(),
+            })
         } else {
             Err(err)
         }
@@ -647,30 +704,67 @@ impl Unicorn {
     }
 
     /// Add a code hook.
-    pub fn add_code_hook(&self,
-                         hook_type: HookType,
-                         begin: u64,
-                         end: u64,
-                         callback: extern "C" fn(engine: uc_handle,
-                                                 address: u64,
-                                                 size: u32,
-                                                 user_data: *mut u64))
-                         -> Result<uc_hook, Error> {
-        let mut hook: libc::size_t = 0;
-        let mut user_data: libc::size_t = 0;
+    pub fn add_code_hook<F>(&mut self,
+                            hook_type: CodeHookType,
+                            begin: u64,
+                            end: u64,
+                            callback: F)
+                            -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u64, u32) + 'static
+    {
+        let mut hook: uc_hook = 0;
         let p_hook: *mut libc::size_t = &mut hook;
-        let p_user_data: *mut libc::size_t = &mut user_data;
+
+        let user_data = Box::new(CodeHook {
+            unicorn: self as *mut _,
+            callback: Box::new(callback),
+        });
+        let p_user_data: *mut libc::size_t = unsafe { mem::transmute(&*user_data) };
+        let _callback: libc::size_t = code_hook_proxy as usize;
+
         let err = unsafe {
-            let _callback: libc::size_t = mem::transmute(callback);
             uc_hook_add(self.handle,
                         p_hook,
-                        hook_type,
+                        mem::transmute(hook_type),
                         _callback,
                         p_user_data,
                         begin,
                         end)
         };
         if err == Error::OK {
+            self.code_callbacks.insert(hook, user_data);
+            Ok(hook)
+        } else {
+            Err(err)
+        }
+    }
+
+    /// Add an interrupt hook.
+    pub fn add_intr_hook<F>(&mut self, begin: u64, end: u64, callback: F) -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u32) + 'static
+    {
+        let mut hook: uc_hook = 0;
+        let p_hook: *mut libc::size_t = &mut hook;
+
+        let user_data = Box::new(IntrHook {
+            unicorn: self as *mut _,
+            callback: Box::new(callback),
+        });
+        let p_user_data: *mut libc::size_t = unsafe { mem::transmute(&*user_data) };
+        let _callback: libc::size_t = intr_hook_proxy as usize;
+
+        let err = unsafe {
+            uc_hook_add(self.handle,
+                        p_hook,
+                        HookType::INTR,
+                        _callback,
+                        p_user_data,
+                        begin,
+                        end)
+        };
+
+        if err == Error::OK {
+            self.intr_callbacks.insert(hook, user_data);
             Ok(hook)
         } else {
             Err(err)
@@ -713,8 +807,9 @@ impl Unicorn {
     /// Remove a hook.
     ///
     /// `hook` is the value returned by either `add_code_hook` or `add_mem_hook`.
-    pub fn remove_hook(&self, hook: uc_hook) -> Result<(), Error> {
+    pub fn remove_hook(&mut self, hook: uc_hook) -> Result<(), Error> {
         let err = unsafe { uc_hook_del(self.handle, hook) } as Error;
+        self.code_callbacks.remove(&hook);
         if err == Error::OK {
             Ok(())
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,10 +190,10 @@ pub trait Cpu {
     }
 
     /// Add an interrupt hook.
-    fn add_intr_hook<F>(&mut self, begin: u64, end: u64, callback: F) -> Result<uc_hook, Error>
+    fn add_intr_hook<F>(&mut self, callback: F) -> Result<uc_hook, Error>
         where F: Fn(&Unicorn, u32) + 'static
     {
-        self.mut_emu().add_intr_hook(begin, end, callback)
+        self.mut_emu().add_intr_hook(callback)
     }
 
     /// Add a memory hook.
@@ -740,7 +740,7 @@ impl Unicorn {
     }
 
     /// Add an interrupt hook.
-    pub fn add_intr_hook<F>(&mut self, begin: u64, end: u64, callback: F) -> Result<uc_hook, Error>
+    pub fn add_intr_hook<F>(&mut self, callback: F) -> Result<uc_hook, Error>
         where F: Fn(&Unicorn, u32) + 'static
     {
         let mut hook: uc_hook = 0;
@@ -759,8 +759,8 @@ impl Unicorn {
                         HookType::INTR,
                         _callback,
                         p_user_data,
-                        begin,
-                        end)
+                        0,
+                        0)
         };
 
         if err == Error::OK {

--- a/src/unicorn_const.rs
+++ b/src/unicorn_const.rs
@@ -93,7 +93,7 @@ pub struct MemRegion {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum MemType {
     READ = 16, // Memory is read from
     WRITE, // Memory is written to
@@ -129,6 +129,28 @@ pub enum HookType {
 pub enum CodeHookType {
     CODE = 1 << 2, // Hook a range of code
     BLOCK = 1 << 3, // Hook basic blocks
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum MemHookType {
+    MEM_READ_UNMAPPED = 1 << 4, // Hook for memory read on unmapped memory
+    MEM_WRITE_UNMAPPED = 1 << 5, // Hook for invalid memory write events
+    MEM_FETCH_UNMAPPED = 1 << 6, // Hook for invalid memory fetch for execution events
+    MEM_READ_PROT = 1 << 7, // Hook for memory read on read-protected memory
+    MEM_WRITE_PROT = 1 << 8, // Hook for memory write on write-protected memory
+    MEM_FETCH_PROT = 1 << 9, // Hook for memory fetch on non-executable memory
+    MEM_READ = 1 << 10, // Hook memory read events.
+    MEM_WRITE = 1 << 11, // Hook memory write events.
+    MEM_FETCH = 1 << 12, // Hook memory fetch for execution events
+    MEM_UNMAPPED = 0b111 << 4, // hook type for all events of unmapped memory access
+    MEM_PROT = 0b111 << 7, // hook type for all events of illegal protected memory access
+    MEM_READ_INVALID = (1 << 4) | (1 << 7), /* Hook type for all events of illegal read memory access */
+    MEM_WRITE_INVALID = (1 << 5) | (1 << 8), /* Hook type for all events of illegal write memory access/ */
+    MEM_FETCH_INVALID = (1 << 6) | (1 << 9), /* Hook type for all events of illegal fetch memory access */
+    MEM_INVALID = (0b111111 << 4), // Hook type for all events of illegal memory access
+    MEM_VALID = (0b111 << 10), // Hook type for all events of valid memory access
+    MEM_ALL = 0b111111111 << 4, // Hook type for all events.
 }
 
 #[repr(C)]

--- a/src/unicorn_const.rs
+++ b/src/unicorn_const.rs
@@ -126,6 +126,13 @@ pub enum HookType {
 
 #[repr(C)]
 #[derive(PartialEq, Debug, Clone, Copy)]
+pub enum CodeHookType {
+    CODE = 1 << 2, // Hook a range of code
+    BLOCK = 1 << 3, // Hook basic blocks
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Query {
     /// The current hardware mode.
     MODE = 1,

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -174,6 +174,14 @@ fn emulate_arm() {
 
     assert_eq!(emu.reg_write(unicorn::RegisterARM::SP, 12), Ok(()));
     assert_eq!(emu.reg_write(unicorn::RegisterARM::R0, 10), Ok(()));
+
+    assert_eq!(emu.emu_start(0x1000,
+                             (0x1000 + arm_code32.len()) as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
+    assert_eq!(emu.reg_read(unicorn::RegisterARM::SP), Ok((0)));
+    assert_eq!(emu.reg_read(unicorn::RegisterARM::R0), Ok((10)));
 }
 
 #[test]

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -1,6 +1,6 @@
 extern crate unicorn;
 
-use unicorn::{Cpu, CpuX86, CpuARM, CpuMIPS, uc_handle};
+use unicorn::{Cpu, CpuX86, CpuARM, CpuMIPS};
 
 #[test]
 fn emulate_x86() {
@@ -101,7 +101,7 @@ fn x86_intr_callback() {
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu.add_intr_hook(callback)
-        .expect("failed to add code hook");
+        .expect("failed to add intr hook");
 
     assert_eq!(emu.emu_start(0x1000,
                              0x1000 + x86_code32.len() as u64,
@@ -114,30 +114,44 @@ fn x86_intr_callback() {
 
 #[test]
 fn x86_mem_callback() {
-    #[allow(unused_variables)]
-    extern "C" fn callback(engine: uc_handle,
-                           mem_type: unicorn::MemType,
-                           address: u64,
-                           size: i32,
-                           value: i64,
-                           user_data: *mut u64) {
-        println!("unmapped mem read at 0x{:08x}!", address);
-    }
+    #[derive(PartialEq, Debug)]
+    struct MemExpectation(unicorn::MemType, u64, usize, i64);
+    let expects = vec![MemExpectation(unicorn::MemType::WRITE, 0x2000, 4, 0xdeadbeef),
+                       MemExpectation(unicorn::MemType::READ_UNMAPPED, 0x10000, 4, 0)];
+    let mems: Vec<MemExpectation> = Vec::new();
+    let mems_cell = ::std::rc::Rc::new(::std::cell::RefCell::new(mems));
 
-    let x86_code32: Vec<u8> = vec![0x8b, 0x00]; // MOV eax, dword [eax]
+    let callback_mems = mems_cell.clone();
+    let callback = move |_: &unicorn::Unicorn,
+                         mem_type: unicorn::MemType,
+                         address: u64,
+                         size: usize,
+                         value: i64| {
+        let mut mems = callback_mems.borrow_mut();
+        mems.push(MemExpectation(mem_type, address, size, value));
+        false
+    };
+
+    // mov eax, 0xdeadbeef;
+    // mov [0x2000], eax;
+    // mov eax, [0x10000];
+    let x86_code32: Vec<u8> = vec![0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0xA3, 0x00, 0x20, 0x00, 0x00,
+                                   0xA1, 0x00, 0x00, 0x01, 0x00];
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
-    let hook = emu.add_mem_hook(unicorn::HookType::MEM_READ_UNMAPPED,
-                      0,
-                      std::u64::MAX,
-                      callback)
+    let hook = emu.add_mem_hook(unicorn::MemHookType::MEM_ALL, 0, std::u64::MAX, callback)
         .expect("failed to add memory hook");
     assert_eq!(emu.reg_write(unicorn::RegisterX86::EAX, 0x123), Ok(()));
-    assert_eq!(emu.emu_start(0x1000, 0x1001, 10 * unicorn::SECOND_SCALE, 1),
+    assert_eq!(emu.emu_start(0x1000,
+                             0x1000 + x86_code32.len() as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             0x1000),
                Err((unicorn::Error::READ_UNMAPPED)));
+
+    assert_eq!(expects, *mems_cell.borrow());
     assert_eq!(emu.remove_hook(hook), Ok(()));
 }
 
@@ -160,14 +174,6 @@ fn emulate_arm() {
 
     assert_eq!(emu.reg_write(unicorn::RegisterARM::SP, 12), Ok(()));
     assert_eq!(emu.reg_write(unicorn::RegisterARM::R0, 10), Ok(()));
-
-    assert_eq!(emu.emu_start(0x1000,
-                             (0x1000 + arm_code32.len()) as u64,
-                             10 * unicorn::SECOND_SCALE,
-                             1000),
-               Ok(()));
-    assert_eq!(emu.reg_read(unicorn::RegisterARM::SP), Ok((0)));
-    assert_eq!(emu.reg_read(unicorn::RegisterARM::R0), Ok((10)));
 }
 
 #[test]

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -100,7 +100,7 @@ fn x86_intr_callback() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
-    let hook = emu.add_intr_hook(0x1000, 0x2000, callback)
+    let hook = emu.add_intr_hook(callback)
         .expect("failed to add code hook");
 
     assert_eq!(emu.emu_start(0x1000,


### PR DESCRIPTION
Change the hooking API to support Rust closure using the user_data parameters. Also, adds some safety measure by splitting the HookType for each callback type. (This way a Rust callback won't be called with invalid parameter types).
If someone more experienced than me with Rust want to have a second look, that would be appreciated.
Missing INSN hook, could add it if I have a few hours off soon.
Not backward compatible ;)