### PR TITLE
Add insn hook

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,31 @@ pub trait Cpu {
         self.mut_emu().add_mem_hook(hook_type, begin, end, callback)
     }
 
+    /// Add an "in" instruction hook.
+    fn add_insn_in_hook<F>(&mut self, callback: F) -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u32, usize) -> u32 + 'static
+    {
+        self.mut_emu().add_insn_in_hook(callback)
+    }
+
+    /// Add an "out" instruction hook.
+    fn add_insn_out_hook<F>(&mut self, callback: F) -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u32, usize, u32) + 'static
+    {
+        self.mut_emu().add_insn_out_hook(callback)
+    }
+
+    /// Add a "syscall" or "sysenter" instruction hook.
+    fn add_insn_sys_hook<F>(&mut self,
+                            insn_type: InsnSysX86,
+                            begin: u64,
+                            end: u64,
+                            callback: F)
+                            -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn) + 'static
+    {
+        self.mut_emu().add_insn_sys_hook(insn_type, begin, end, callback)
+    }
     /// Remove a hook.
     ///
     /// `hook` is the value returned by either `add_code_hook` or `add_mem_hook`.
@@ -455,11 +480,17 @@ extern "C" fn insn_out_hook_proxy(_: uc_handle,
     (insn_hook.callback)(unsafe { &*insn_hook.unicorn }, port, size, value);
 }
 
+extern "C" fn insn_sys_hook_proxy(_: uc_handle, user_data: *mut InsnSysHook) {
+    let insn_hook = unsafe { &mut *user_data };
+    (insn_hook.callback)(unsafe { &*insn_hook.unicorn });
+}
+
 type CodeHook = UnicornHook<Box<Fn(&Unicorn, u64, u32)>>;
 type IntrHook = UnicornHook<Box<Fn(&Unicorn, u32)>>;
 type MemHook = UnicornHook<Box<Fn(&Unicorn, MemType, u64, usize, i64) -> bool>>;
 type InsnInHook = UnicornHook<Box<Fn(&Unicorn, u32, usize) -> u32>>;
 type InsnOutHook = UnicornHook<Box<Fn(&Unicorn, u32, usize, u32)>>;
+type InsnSysHook = UnicornHook<Box<Fn(&Unicorn)>>;
 
 /// Internal : A Unicorn emulator instance, use one of the Cpu structs instead.
 pub struct Unicorn {
@@ -469,6 +500,7 @@ pub struct Unicorn {
     mem_callbacks: HashMap<uc_hook, Box<MemHook>>,
     insn_in_callbacks: HashMap<uc_hook, Box<InsnInHook>>,
     insn_out_callbacks: HashMap<uc_hook, Box<InsnOutHook>>,
+    insn_sys_callbacks: HashMap<uc_hook, Box<InsnSysHook>>,
 }
 
 impl Error {
@@ -524,6 +556,7 @@ impl Unicorn {
                 mem_callbacks: HashMap::default(),
                 insn_in_callbacks: HashMap::default(),
                 insn_out_callbacks: HashMap::default(),
+                insn_sys_callbacks: HashMap::default(),
             })
         } else {
             Err(err)
@@ -848,13 +881,8 @@ impl Unicorn {
     }
 
     /// Add an "in" instruction hook.
-    pub fn add_insn_in_hook<F>(&mut self,
-                               insn_type: InsnType,
-                               begin: u64,
-                               end: u64,
-                               callback: F)
-                               -> Result<uc_hook, Error>
-        where F: Fn(&Unicorn, u32, usize) + 'static
+    pub fn add_insn_in_hook<F>(&mut self, callback: F) -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u32, usize) -> u32 + 'static
     {
         let mut hook: uc_hook = 0;
         let p_hook: *mut libc::size_t = &mut hook;
@@ -864,7 +892,78 @@ impl Unicorn {
             callback: Box::new(callback),
         });
         let p_user_data: *mut libc::size_t = unsafe { mem::transmute(&*user_data) };
-        let _callback: libc::size_t = intr_hook_proxy as usize;
+        let _callback: libc::size_t = insn_in_hook_proxy as usize;
+
+        let err = unsafe {
+            uc_hook_add(self.handle,
+                        p_hook,
+                        HookType::INSN,
+                        _callback,
+                        p_user_data,
+                        0,
+                        0,
+                        x86_const::InsnX86::IN)
+        };
+
+        if err == Error::OK {
+            self.insn_in_callbacks.insert(hook, user_data);
+            Ok(hook)
+        } else {
+            Err(err)
+        }
+    }
+
+    /// Add an "out" instruction hook.
+    pub fn add_insn_out_hook<F>(&mut self, callback: F) -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn, u32, usize, u32) + 'static
+    {
+        let mut hook: uc_hook = 0;
+        let p_hook: *mut libc::size_t = &mut hook;
+
+        let user_data = Box::new(InsnOutHook {
+            unicorn: self as *mut _,
+            callback: Box::new(callback),
+        });
+        let p_user_data: *mut libc::size_t = unsafe { mem::transmute(&*user_data) };
+        let _callback: libc::size_t = insn_out_hook_proxy as usize;
+
+        let err = unsafe {
+            uc_hook_add(self.handle,
+                        p_hook,
+                        HookType::INSN,
+                        _callback,
+                        p_user_data,
+                        0,
+                        0,
+                        x86_const::InsnX86::OUT)
+        };
+
+        if err == Error::OK {
+            self.insn_out_callbacks.insert(hook, user_data);
+            Ok(hook)
+        } else {
+            Err(err)
+        }
+    }
+
+    /// Add a "syscall" or "sysenter" instruction hook.
+    pub fn add_insn_sys_hook<F>(&mut self,
+                                insn_type: InsnSysX86,
+                                begin: u64,
+                                end: u64,
+                                callback: F)
+                                -> Result<uc_hook, Error>
+        where F: Fn(&Unicorn) + 'static
+    {
+        let mut hook: uc_hook = 0;
+        let p_hook: *mut libc::size_t = &mut hook;
+
+        let user_data = Box::new(InsnSysHook {
+            unicorn: self as *mut _,
+            callback: Box::new(callback),
+        });
+        let p_user_data: *mut libc::size_t = unsafe { mem::transmute(&*user_data) };
+        let _callback: libc::size_t = insn_sys_hook_proxy as usize;
 
         let err = unsafe {
             uc_hook_add(self.handle,
@@ -873,11 +972,12 @@ impl Unicorn {
                         _callback,
                         p_user_data,
                         begin,
-                        end)
+                        end,
+                        insn_type)
         };
 
         if err == Error::OK {
-            self.intr_callbacks.insert(hook, user_data);
+            self.insn_sys_callbacks.insert(hook, user_data);
             Ok(hook)
         } else {
             Err(err)
@@ -894,6 +994,9 @@ impl Unicorn {
         self.intr_callbacks.remove(&hook);
         self.mem_callbacks.remove(&hook);
         self.insn_in_callbacks.remove(&hook);
+        self.insn_out_callbacks.remove(&hook);
+        self.insn_sys_callbacks.remove(&hook);
+
         if err == Error::OK {
             Ok(())
         } else {

--- a/src/x86_const.rs
+++ b/src/x86_const.rs
@@ -1,5 +1,5 @@
 // X86 registers
-#[repr(i32)]
+#[repr(C)]
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum RegisterX86 {
     INVALID = 0,
@@ -244,4 +244,20 @@ pub enum RegisterX86 {
     R13W,
     R14W,
     R15W,
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum InsnX86 {
+    IN = 218,
+    OUT = 500,
+    SYSCALL = 699,
+    SYSENTER = 700,
+}
+
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum InsnSysX86 {
+    SYSCALL = InsnX86::SYSCALL as isize,
+    SYSENTER = InsnX86::SYSENTER as isize,
 }

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -158,6 +158,36 @@ fn x86_mem_callback() {
 }
 
 #[test]
+fn x86_insn_in_callback() {
+    #[derive(PartialEq, Debug)]
+    struct InsnInExpectation(u32, usize);
+    let expect = InsnInExpectation(0x10, 4);
+    let insn_cell = Rc::new(RefCell::new(expect));
+
+    let callback_insn = insn_cell.clone();
+    let callback = move |_: &unicorn::Unicorn, port: u32, size: usize| {
+        *callback_insn.borrow_mut() = InsnInExpectation(port, size);
+    };
+
+    let x86_code32: Vec<u8> = vec![0xe5, 0x10]; // IN eax, 0x10;
+
+    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
+
+    let hook = emu.add_insn_in_hook(InsnType::X86_INS_OUT, 1, 0, callback)
+        .expect("failed to add in hook");
+
+    assert_eq!(emu.emu_start(0x1000,
+                             0x1000 + x86_code32.len() as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
+    assert_eq!(expect, *insn_cell.borrow());
+    assert_eq!(emu.remove_hook(hook), Ok(()));
+}
+
+#[test]
 fn emulate_arm() {
     let arm_code32: Vec<u8> = vec![0x83, 0xb0]; // sub    sp, #0xc
 

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -162,11 +162,12 @@ fn x86_insn_in_callback() {
     #[derive(PartialEq, Debug)]
     struct InsnInExpectation(u32, usize);
     let expect = InsnInExpectation(0x10, 4);
-    let insn_cell = Rc::new(RefCell::new(expect));
+    let insn_cell = Rc::new(RefCell::new(InsnInExpectation(0, 0)));
 
     let callback_insn = insn_cell.clone();
     let callback = move |_: &unicorn::Unicorn, port: u32, size: usize| {
         *callback_insn.borrow_mut() = InsnInExpectation(port, size);
+        return 0;
     };
 
     let x86_code32: Vec<u8> = vec![0xe5, 0x10]; // IN eax, 0x10;
@@ -175,11 +176,75 @@ fn x86_insn_in_callback() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
-    let hook = emu.add_insn_in_hook(InsnType::X86_INS_OUT, 1, 0, callback)
+    let hook = emu.add_insn_in_hook(callback)
         .expect("failed to add in hook");
 
     assert_eq!(emu.emu_start(0x1000,
                              0x1000 + x86_code32.len() as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
+    assert_eq!(expect, *insn_cell.borrow());
+    assert_eq!(emu.remove_hook(hook), Ok(()));
+}
+
+#[test]
+fn x86_insn_out_callback() {
+    #[derive(PartialEq, Debug)]
+    struct InsnOutExpectation(u32, usize, u32);
+    let expect = InsnOutExpectation(0x46, 1, 0x32);
+    let insn_cell = Rc::new(RefCell::new(InsnOutExpectation(0, 0, 0)));
+
+    let callback_insn = insn_cell.clone();
+    let callback = move |_: &unicorn::Unicorn, port: u32, size: usize, value: u32| {
+        *callback_insn.borrow_mut() = InsnOutExpectation(port, size, value);
+    };
+
+    let x86_code32: Vec<u8> = vec![0xb0, 0x32, 0xe6, 0x46]; // MOV al, 0x32; OUT  0x46, al;
+
+    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
+
+    let hook = emu.add_insn_out_hook(callback)
+        .expect("failed to add in hook");
+
+    assert_eq!(emu.emu_start(0x1000,
+                             0x1000 + x86_code32.len() as u64,
+                             10 * unicorn::SECOND_SCALE,
+                             1000),
+               Ok(()));
+    assert_eq!(expect, *insn_cell.borrow());
+    assert_eq!(emu.remove_hook(hook), Ok(()));
+}
+
+#[test]
+fn x86_insn_sys_callback() {
+    #[derive(PartialEq, Debug)]
+    struct InsnSysExpectation(u64);
+    let expect = InsnSysExpectation(0xdeadbeef);
+    let insn_cell = Rc::new(RefCell::new(InsnSysExpectation(0)));
+
+    let callback_insn = insn_cell.clone();
+    let callback = move |uc: &unicorn::Unicorn| {
+        println!("!!!!");
+        let rax = uc.reg_read(unicorn::RegisterX86::RAX as i32).unwrap();
+        *callback_insn.borrow_mut() = InsnSysExpectation(rax);
+    };
+
+    // MOV rax, 0xdeadbeef; SYSCALL;
+    let x86_code: Vec<u8> = vec![0x48, 0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x0F,
+                                 0x05];
+
+    let mut emu = CpuX86::new(unicorn::Mode::MODE_64).expect("failed to instantiate emulator");
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_write(0x1000, &x86_code), Ok(()));
+
+    let hook = emu.add_insn_sys_hook(unicorn::InsnSysX86::SYSCALL, 1, 0, callback)
+        .expect("failed to add in hook");
+
+    assert_eq!(emu.emu_start(0x1000,
+                             0x1000 + x86_code.len() as u64,
                              10 * unicorn::SECOND_SCALE,
                              1000),
                Ok(()));


### PR DESCRIPTION
Add the insn hooks, including hook to in/out, syscall and sysenter. As it turns out, this is need to hook syscall for x86-64.