### PR TITLE
build and link unicorn from source using experimental noglib branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "unicorn"]
+	path = unicorn
+	url = https://github.com/unicorn-engine/unicorn
+	branch = noglib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ documentation = "http://ekse.github.io/unicorn/"
 license = "GPL-2.0"
 readme = "README.md"
 include = ["src/*", "tests/*", "Cargo.toml", "COPYING", "README.md"]
+build = "build.rs"
+links = "unicorn"
+
+[build-dependencies]
+gcc = "0.3"
 
 [dependencies]
 bitflags = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+extern crate gcc;
+
+use std::path::{Path};
+use std::process::Command;
+use std::env;
+
+fn main() {
+    if !Path::new("unicorn/.git").exists() {
+        let _ = Command::new("git").args(&["submodule", "update", "--init", "--depth", "5"])
+            .status();
+    }
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let _ = Command::new("./make.sh").current_dir("unicorn").status();
+    let capstone = "libunicorn.a";
+    let _ = Command::new("cp").current_dir("unicorn").arg(&capstone).arg(&out_dir).status();
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=unicorn");
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,7 +3,6 @@ use std::os::raw::c_char;
 use unicorn_const::{Arch, MemRegion, Mode, Error, HookType, Query};
 use {uc_handle, uc_hook};
 
-#[link(name = "unicorn")]
 extern "C" {
     pub fn uc_version(major: *const u32, minor: *const u32) -> u32;
     pub fn uc_arch_supported(arch: Arch) -> bool;


### PR DESCRIPTION
This probably needs some work, and I'm little too busy to tweak this right now, but basic gist is there for building unicorn from source using new `noglib` branch after https://github.com/unicorn-engine/unicorn/issues/686 lands

You may want to add pkglib test as well, but I don't see many distros including unicorn static libs?

I tried getting this to compile with wasm32 target, but had some issues; probably need to pass a different C compiler to unicorn build, dunno, but should be possible (and awesome)