### PR TITLE
Methods that alter the unicorn instance state now require mut references

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -12,7 +12,7 @@ fn main() {
         unicorn::arch_supported(unicorn::Arch::MIPS)
     );
 
-    let emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to create emulator");
+    let mut emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to create emulator");
 
     let page_size = emu.query(unicorn::Query::PAGE_SIZE)
         .expect("failed to query page size");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,20 +110,20 @@ pub trait Cpu {
 
     /// Write an unsigned value register.
     fn reg_write(&mut self, reg: Self::Reg, value: u64) -> Result<(), Error> {
-        self.emu().reg_write(reg.to_i32(), value)
+        self.mut_emu().reg_write(reg.to_i32(), value)
     }
 
     /// Write a signed 32-bit value to a register.
-    fn reg_write_i32(&self, reg: Self::Reg, value: i32) -> Result<(), Error> {
-        self.emu().reg_write_i32(reg.to_i32(), value)
+    fn reg_write_i32(&mut self, reg: Self::Reg, value: i32) -> Result<(), Error> {
+        self.mut_emu().reg_write_i32(reg.to_i32(), value)
     }
 
     /// Map a memory region in the emulator at the specified address.
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
-    fn mem_map(&self, address: u64, size: libc::size_t, perms: Protection) -> Result<(), Error> {
-        self.emu().mem_map(address, size, perms)
+    fn mem_map(&mut self, address: u64, size: libc::size_t, perms: Protection) -> Result<(), Error> {
+        self.mut_emu().mem_map(address, size, perms)
     }
 
     /// Map an existing memory region in the emulator at the specified address.
@@ -138,26 +138,26 @@ pub trait Cpu {
     ///
     /// `ptr` is a pointer to the provided memory region that will be used by the emulator.
     unsafe fn mem_map_ptr<T>(
-        &self,
+        &mut self,
         address: u64,
         size: libc::size_t,
         perms: Protection,
         ptr: *mut T,
     ) -> Result<(), Error> {
-        self.emu().mem_map_ptr(address, size, perms, ptr)
+        self.mut_emu().mem_map_ptr(address, size, perms, ptr)
     }
 
     /// Unmap a memory region.
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
-    fn mem_unmap(&self, address: u64, size: libc::size_t) -> Result<(), Error> {
-        self.emu().mem_unmap(address, size)
+    fn mem_unmap(&mut self, address: u64, size: libc::size_t) -> Result<(), Error> {
+        self.mut_emu().mem_unmap(address, size)
     }
 
     /// Write a range of bytes to memory at the specified address.
-    fn mem_write(&self, address: u64, bytes: &[u8]) -> Result<(), Error> {
-        self.emu().mem_write(address, bytes)
+    fn mem_write(&mut self, address: u64, bytes: &[u8]) -> Result<(), Error> {
+        self.mut_emu().mem_write(address, bytes)
     }
 
     /// Read a range of bytes from memory at the specified address.
@@ -169,8 +169,8 @@ pub trait Cpu {
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
-    fn mem_protect(&self, address: u64, size: usize, perms: Protection) -> Result<(), Error> {
-        self.emu().mem_protect(address, size, perms)
+    fn mem_protect(&mut self, address: u64, size: usize, perms: Protection) -> Result<(), Error> {
+        self.mut_emu().mem_protect(address, size, perms)
     }
 
     /// Returns a vector with the memory regions that are mapped in the emulator.
@@ -184,16 +184,16 @@ pub trait Cpu {
     /// is hit. `timeout` specifies a duration in microseconds after which the emulation is
     /// stopped (infinite execution if set to 0). `count` is the maximum number of instructions
     /// to emulate (emulate all the available instructions if set to 0).
-    fn emu_start(&self, begin: u64, until: u64, timeout: u64, count: usize) -> Result<(), Error> {
-        self.emu().emu_start(begin, until, timeout, count)
+    fn emu_start(&mut self, begin: u64, until: u64, timeout: u64, count: usize) -> Result<(), Error> {
+        self.mut_emu().emu_start(begin, until, timeout, count)
     }
 
     /// Stop the emulation.
     ///
     /// This is usually called from callback function in hooks.
     /// NOTE: For now, this will stop the execution only after the current block.
-    fn emu_stop(&self) -> Result<(), Error> {
-        self.emu().emu_stop()
+    fn emu_stop(&mut self) -> Result<(), Error> {
+        self.mut_emu().emu_stop()
     }
 
     /// Add a code hook.

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -45,7 +45,7 @@ fn emulate_x86() {
 fn emulate_x86_negative_values() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
-    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
 
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
@@ -86,7 +86,7 @@ fn callback_lifetime_init() -> unicorn::CpuX86 {
 #[test]
 fn test_callback_lifetime() {
     // Regression test for https://github.com/ekse/unicorn-rs/issues/13
-    let emu = callback_lifetime_init();
+    let mut emu = callback_lifetime_init();
     println!("Foobar");
     assert_eq!(
         emu.emu_start(0x1000, 0x1002, 10 * unicorn::SECOND_SCALE, 1000),
@@ -381,7 +381,7 @@ fn emulate_mips() {
 
 #[test]
 fn mem_unmapping() {
-    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_unmap(0x1000, 0x4000), Ok(()));
 }


### PR DESCRIPTION
I've been running into some mysterious segfaults when using these unicorn bindings in a highly concurrent genetic programming system I'm working on, and I had some suspicion that they *might* be due to race conditions resulting from aggressive optimizations made by the rust compiler, while under the impression that, e.g., `emu.mem_write()` doesn't require `emu` to be mutable. I'm still not sure if this was the case, but with the way things are currently set up, it seems like the sort of problem that _could_ happen. 

In this PR, I've changed the signature of all methods that need to somehow alter the unicorn instance's state so that they require a `mut` reference to that instance. I've also adjusted the tests and examples so that they use `let mut emu = ...` instead of `let emu = ...` where necessary. 