### PR TITLE
Add RESOURCE and EXCEPTION error cases

### DIFF
--- a/libunicorn-sys/src/unicorn_const.rs
+++ b/libunicorn-sys/src/unicorn_const.rs
@@ -71,6 +71,8 @@ pub enum Error {
     WRITE_UNALIGNED, // Unaligned write
     FETCH_UNALIGNED, // Unaligned fetch
     HOOK_EXIST, // hook for this event already existed
+    RESOURCE, // Insufficient resource: uc_emu_start()
+    EXCEPTION, // Unhandled CPU exception
 }
 
 


### PR DESCRIPTION
A couple of error cases were missing from these bindings. When one of these cases are hit during runtime, the error case "OK" matches, which is not good.