### PR TITLE
first-class error support for Error

### DIFF
--- a/libunicorn-sys/src/lib.rs
+++ b/libunicorn-sys/src/lib.rs
@@ -4,8 +4,11 @@ extern crate bitflags;
 
 pub mod unicorn_const;
 
-use std::ffi::CStr;
-use std::os::raw::c_char;
+use std::{
+    ffi::CStr, 
+    os::raw::c_char, 
+    error, fmt
+};
 use unicorn_const::{Arch, MemRegion, Mode, Error, HookType, Query};
 
 #[allow(non_camel_case_types)]
@@ -88,4 +91,21 @@ impl Error {
 /// Returns a string for the specified error code.
 pub fn error_msg(error: Error) -> String {
     unsafe { CStr::from_ptr(uc_strerror(error)).to_string_lossy().into_owned() }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        unsafe { CStr::from_ptr(uc_strerror(*self)).to_str().unwrap() }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
+    }
 }


### PR DESCRIPTION
Hello all,

This PR just tries to add first-class error support for `unicorn::Error`; that helps using `unicorn-rs` more conveniently in other projects with `?` syntax. For example, with [quicli](https://github.com/killercup/quicli):

```
extern crate unicorn;

#[macro_use]
extern crate quicli;

use unicorn::{CpuX86, Mode};

main!(|| {
    let cpu_amd64 = CpuX86::new(Mode::MODE_64)?;
    let cpu_x86 = CpuX86::new(Mode::MODE_32)?;
    ...
});
```

Many thanks for any comment.