### PR TITLE
Update the package to version 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ readme = "README.md"
 gcc = "0.3"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 libunicorn-sys = { path = "libunicorn-sys", version = "0.8.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicorn"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["Sébastien Duquette <ekse.0x@gmail.com>"]
 description = "Rust bindings for the unicorn emulator"
@@ -15,4 +15,4 @@ gcc = "0.3"
 [dependencies]
 bitflags = "1.0"
 libc = "0.2"
-libunicorn-sys = { path = "libunicorn-sys", version = "0.8.0" }
+libunicorn-sys = { path = "libunicorn-sys", version = "0.9.0" }

--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@
 Rust bindings for the [unicorn](http://www.unicorn-engine.org/) CPU emulator.
 
 ```rust
-extern crate unicorn;
-
 use unicorn::{Cpu, CpuX86};
 
 fn main() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
     let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    let _ = emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL);
+    let _ = emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL);
     let _ = emu.mem_write(0x1000, &x86_code32);
     let _ = emu.reg_write_i32(unicorn::RegisterX86::ECX, -10);
     let _ = emu.reg_write_i32(unicorn::RegisterX86::EDX, -50);
@@ -45,6 +43,17 @@ unicorn = "0.8.0"
 ```
 
 ## Changelog
+
+### 0.9
+
+Error now implements the Error trait (thanks to @tathanhdinh), the RESOURCE and EXCEPTION
+error cases are now supported (thanks to @endeav0r). The CPU context can now be
+saved and restored (thanks to @oblivia-simplex). You can find an example use in the
+test `x86_context_save_and_restore`, in tests/unicorn.rs. The ffi bindings crate 
+unicorn-sys is now no_std by default (thanks to @strake). Finally the crate was migrated
+to Rust edition 2018.
+
+Thank you again to all the contributors, your help is always appreciated.
 
 ### 0.8.0
 
@@ -86,3 +95,7 @@ Contributors:
 - petevine for reviewing the project and adding tests
 - jschievink for his help with the API design
 - m4b for the build.rs script
+- TA Thanh Dinh
+- Lucca Fraser (@oblivia-simplex)
+- Matthew Farkas-Dyck (@strake)
+- endeav0r 

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -23,9 +23,9 @@ fn main() {
 
     println!("Sample error message : {}", unicorn::Error::HOOK.msg());
 
-    emu.mem_map(0x10000, 0x4000, unicorn::PROT_ALL)
+    emu.mem_map(0x10000, 0x4000, unicorn::Protection::ALL)
         .expect("failed to map first memory region");
-    emu.mem_map(0x20000, 0x4000, unicorn::PROT_ALL)
+    emu.mem_map(0x20000, 0x4000, unicorn::Protection::ALL)
         .expect("failed to map second memory region");
     let regions = emu.mem_regions()
         .expect("failed to retrieve memory mappings");

--- a/libunicorn-sys/Cargo.toml
+++ b/libunicorn-sys/Cargo.toml
@@ -20,12 +20,11 @@ name = "libunicorn_sys"
 
 [build-dependencies]
 build-helper = "0.1"
-gcc = "0.3"
-os_type="0.6"
+os_type="2.2"
 pkg-config = "0.3"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = { version = "0.2", default-features = false }
 
 [features]

--- a/libunicorn-sys/Cargo.toml
+++ b/libunicorn-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libunicorn-sys"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["Sébastien Duquette <ekse.0x@gmail.com>"]
 description = "Rust bindings for the unicorn emulator"

--- a/libunicorn-sys/build.rs
+++ b/libunicorn-sys/build.rs
@@ -1,5 +1,4 @@
 extern crate build_helper;
-extern crate gcc;
 extern crate os_type;
 extern crate pkg_config;
 
@@ -76,7 +75,7 @@ fn main() {
     }
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    let make_args = match os_type::current_platform() {
+    let make_args = match os_type::current_platform().os_type {
         os_type::OSType::OSX => ["macos-universal-no"],
         _ => [""],
     };

--- a/libunicorn-sys/src/unicorn_const.rs
+++ b/libunicorn-sys/src/unicorn_const.rs
@@ -78,14 +78,21 @@ pub enum Error {
 
 bitflags! {
 #[repr(C)]
-pub flags Protection : u32 {
-        const PROT_NONE = 0,
-        const PROT_READ = 1,
-        const PROT_WRITE = 2,
-        const PROT_EXEC = 4,
-        const PROT_ALL = 7,
+pub struct Protection : u32 {
+        const NONE = 0;
+        const READ = 1;
+        const WRITE = 2;
+        const EXEC = 4;
+        const ALL = 7;
     }
 }
+
+// Map to the PROT_ constants to maintain backward compatibility.
+pub const PROT_NONE: Protection = Protection::NONE;
+pub const PROT_READ: Protection = Protection::READ;
+pub const PROT_WRITE: Protection = Protection::WRITE;
+pub const PROT_EXEC: Protection = Protection::EXEC;
+pub const PROT_ALL: Protection = Protection::ALL;
 
 #[repr(C)]
 #[derive(Debug, Clone)]

--- a/libunicorn-sys/src/unicorn_const.rs
+++ b/libunicorn-sys/src/unicorn_const.rs
@@ -87,11 +87,21 @@ pub struct Protection : u32 {
     }
 }
 
-// Map to the PROT_ constants to maintain backward compatibility.
+
+#[deprecated]
+/// Use Protection::NONE instead.
 pub const PROT_NONE: Protection = Protection::NONE;
+#[deprecated]
+/// Use Protection::READ instead.
 pub const PROT_READ: Protection = Protection::READ;
+#[deprecated]
+/// Use Protection::WRITE instead.
 pub const PROT_WRITE: Protection = Protection::WRITE;
+#[deprecated]
+/// Use Protection::EXEC instead.
 pub const PROT_EXEC: Protection = Protection::EXEC;
+#[deprecated]
+/// Use Protection::ALL instead.
 pub const PROT_ALL: Protection = Protection::ALL;
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!    let x86_code32 : Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 //!
 //!    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-//!    emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL);
+//!    emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL);
 //!    emu.mem_write(0x1000, &x86_code32);
 //!    emu.reg_write_i32(unicorn::RegisterX86::ECX, -10);
 //!    emu.reg_write_i32(unicorn::RegisterX86::EDX, -50);

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -166,7 +166,7 @@ fn emulate_x86() {
         (Err(unicorn::Error::WRITE_UNMAPPED))
     );
 
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
         emu.mem_read(0x1000, x86_code32.len()),
@@ -195,7 +195,7 @@ fn emulate_x86_negative_values() {
 
     let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
 
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     assert_eq!(emu.reg_write_i32(unicorn::RegisterX86::ECX, -10), Ok(()));
@@ -218,7 +218,7 @@ fn callback_lifetime_init() -> unicorn::CpuX86 {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let callback = move |uc: &unicorn::Unicorn, _: u64, _: u32| {
@@ -259,7 +259,7 @@ fn x86_code_callback() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu.add_code_hook(unicorn::CodeHookType::CODE, 0x1000, 0x2000, callback)
@@ -287,7 +287,7 @@ fn x86_intr_callback() {
     let x86_code32: Vec<u8> = vec![0xcd, 0x80]; // INT 0x80;
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu.add_intr_hook(callback)
@@ -336,7 +336,7 @@ fn x86_mem_callback() {
     ];
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu.add_mem_hook(unicorn::MemHookType::MEM_ALL, 0, std::u64::MAX, callback)
@@ -372,7 +372,7 @@ fn x86_insn_in_callback() {
     let x86_code32: Vec<u8> = vec![0xe5, 0x10]; // IN eax, 0x10;
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu.add_insn_in_hook(callback)
@@ -406,7 +406,7 @@ fn x86_insn_out_callback() {
     let x86_code32: Vec<u8> = vec![0xb0, 0x32, 0xe6, 0x46]; // MOV al, 0x32; OUT  0x46, al;
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu.add_insn_out_hook(callback)
@@ -445,7 +445,7 @@ fn x86_insn_sys_callback() {
     ];
 
     let mut emu = CpuX86::new(unicorn::Mode::MODE_64).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code), Ok(()));
 
     let hook = emu.add_insn_sys_hook(unicorn::InsnSysX86::SYSCALL, 1, 0, callback)
@@ -508,7 +508,7 @@ fn emulate_mips() {
     let mips_code32 = vec![0x56, 0x34, 0x21, 0x34]; // ori $at, $at, 0x3456;
 
     let emu = CpuMIPS::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &mips_code32), Ok(()));
     assert_eq!(
         emu.mem_read(0x1000, mips_code32.len()),
@@ -530,7 +530,7 @@ fn emulate_mips() {
 #[test]
 fn mem_unmapping() {
     let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
-    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+    assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_unmap(0x1000, 0x4000), Ok(()));
 }
 
@@ -549,7 +549,7 @@ fn mem_map_ptr() {
     );
 
     assert_eq!(
-        unsafe { emu.mem_map_ptr(0x1000, 0x4000, unicorn::PROT_ALL, mem.as_mut_ptr()) },
+        unsafe { emu.mem_map_ptr(0x1000, 0x4000, unicorn::Protection::ALL, mem.as_mut_ptr()) },
         Ok(())
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
@@ -585,7 +585,7 @@ fn mem_map_ptr() {
     );
 
     assert_eq!(
-        unsafe { emu.mem_map_ptr(0x1000, 0x4000, unicorn::PROT_ALL, mem.as_mut_ptr()) },
+        unsafe { emu.mem_map_ptr(0x1000, 0x4000, unicorn::Protection::ALL, mem.as_mut_ptr()) },
         Ok(())
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
@@ -618,7 +618,7 @@ fn x86_context_save_and_restore () {
             0x48, 0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x05
         ];
         let emu = CpuX86::new(mode).expect("failed to instantiate emulator");
-        assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+        assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
         assert_eq!(emu.mem_write(0x1000, &x86_code), Ok(()));
         let _ = emu.emu_start(0x1000,
                               (0x1000 + x86_code.len()) as u64,


### PR DESCRIPTION
With the update to bitflags 1.0, the protection flags are now member of the Protection struct. The constants such PROT_ALL are still available to maintain backwards compatibility.