### PR TITLE
modules should not be public

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ fn main() {
     let _ = emu.reg_write_i32(unicorn::RegisterX86::EDX, -50);
 
     let _ = emu.emu_start(0x1000, (0x1000 + x86_code32.len()) as u64, 10 * unicorn::SECOND_SCALE, 1000);
-    assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::ECX), Ok((-9)));
-    assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::EDX), Ok((-51)));
+    assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::ECX), Ok(-9));
+    assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::EDX), Ok(-51));
 }
 ```
 

--- a/libunicorn-sys/build.rs
+++ b/libunicorn-sys/build.rs
@@ -1,11 +1,9 @@
-extern crate build_helper;
-extern crate os_type;
-extern crate pkg_config;
-
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::env;
-use std::ffi::{OsString, OsStr};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    env,
+    ffi::{OsString, OsStr},
+};
 
 use build_helper::rustc::{link_search, link_lib};
 
@@ -61,6 +59,8 @@ fn get_vcvars_path_and_platform() -> (OsString, &'static str) {
 }
 
 fn main() {
+    println!("cargo:rerun-if-changed=unicorn");
+
     if !build_helper::windows() {
         if Command::new("pkg-config").output().is_ok()
             && pkg_config::Config::new().atleast_version("1.0.0").probe("unicorn").is_ok() {

--- a/libunicorn-sys/src/unicorn_const.rs
+++ b/libunicorn-sys/src/unicorn_const.rs
@@ -184,3 +184,6 @@ pub enum Query {
     /// The page size used by the emulator
     PAGE_SIZE,
 }
+
+pub const BINDINGS_MAJOR: u32 = 1;
+pub const BINDINGS_MINOR: u32 = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,32 +24,32 @@
 //! }
 //! ```
 //!
-extern crate libunicorn_sys as ffi;
+use libunicorn_sys as ffi;
 
-pub mod arm64_const;
-pub mod arm_const;
-pub mod m68k_const;
-pub mod mips_const;
-pub mod sparc_const;
-pub mod x86_const;
+mod arm64_const;
+mod arm_const;
+mod m68k_const;
+mod mips_const;
+mod sparc_const;
+mod x86_const;
 
-use std::mem;
-use std::collections::HashMap;
+use std::{
+    mem,
+    collections::HashMap,
+};
 
-use crate::ffi::*;
-
-pub use crate::arm64_const::*;
-pub use crate::arm_const::*;
-pub use crate::m68k_const::*;
-pub use crate::mips_const::*;
-pub use crate::sparc_const::*;
-pub use crate::unicorn_const::*;
-pub use crate::x86_const::*;
-pub use crate::ffi::{uc_handle, uc_hook, uc_context};
-pub use crate::ffi::unicorn_const;
-
-pub const BINDINGS_MAJOR: u32 = 1;
-pub const BINDINGS_MINOR: u32 = 0;
+pub use crate::{
+    arm64_const::*,
+    arm_const::*,
+    m68k_const::*,
+    mips_const::*,
+    sparc_const::*,
+    ffi::{
+        unicorn_const::*,
+        *
+    },
+    x86_const::*,
+};
 
 #[derive(Debug)]
 pub struct Context {
@@ -579,7 +579,7 @@ impl Unicorn {
         let err = unsafe { uc_open(arch, mode, &mut handle) };
         if err == Error::OK {
             Ok(Box::new(Unicorn {
-                handle: handle,
+                handle,
                 code_callbacks: HashMap::default(),
                 intr_callbacks: HashMap::default(),
                 mem_callbacks: HashMap::default(),


### PR DESCRIPTION
Bonjour à tous,

This PR are just minor changes: 
  - remove some `extern crate` because they're not needed in Rust 2018.
  - some modules doesn't need to be `pub` since they have been rexported in `pub use crate`
  - add `cargo:rerun-if-changed=unicorn` to rebuild if `unicorn` are modified externally
  - `BINDINGS_MAJOR/MINOR` are put into low-level (IMHO, they should not be exported by the high-level binding!?)

Merci. 