### PR TITLE
generic register read/write

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,50 @@
+macro_rules! implement_register {
+    ($reg_arch:ty) => {
+        impl Register for $reg_arch {
+            fn to_i32(&self) -> i32 {
+                *self as i32
+            }
+        }
+    };
+}
+
+macro_rules! implement_emulator {
+    ($emu_type_doc:meta, $emu_instance_doc:meta, $cpu:ident, $arch:expr, $reg:ty) => {
+        #[$emu_type_doc]
+        pub struct $cpu {
+            emu: Box<Unicorn>,
+        }
+
+        impl $cpu {
+            #[$emu_instance_doc]
+            pub fn new(mode: Mode) -> Result<Self> {
+                let emu = Unicorn::new($arch, mode);
+                match emu {
+                    Ok(x) => Ok(Self { emu: x }),
+                    Err(x) => Err(x),
+                }
+            }
+        }
+
+        impl Cpu for $cpu {
+            type Reg = $reg;
+
+            fn emu(&self) -> &Unicorn {
+                &self.emu
+            }
+
+            fn mut_emu(&mut self) -> &mut Unicorn {
+                &mut self.emu
+            }
+        }
+    };
+}
+
+macro_rules! destructure_hook {
+    ($hook_type:path, $hook:ident) => {
+        {
+            let $hook_type { unicorn, ref mut callback } = unsafe { &mut *$hook };
+            (unsafe { &**unicorn }, callback)
+        }
+    };
+}


### PR DESCRIPTION
Hello all,

This PR tries to simplify the implementation of register read/write methods, briefly:

- add type alias `type Result<T> = std::result::Result<T, Error>`
- use a generic read (or write) `reg_..._generic`, and versions `u64` and `i32` are generated by monomorphization, e.g.

https://github.com/ekse/unicorn-rs/blob/90b0890538ce55fe7e95c9ef3f1f555814928262/src/lib.rs#L486-L519

becomes

```rust
fn reg_write_generic<T: Sized>(&self, regid: i32, value: T) -> Result<()> {
    let p_value: *const T = &value;
    let err = unsafe { uc_reg_write(self.handle, regid, p_value as *const libc::c_void) };
    if err == Error::OK {
        Ok(())
    } else {
        Err(err)
    }
}

/// Write an unsigned value register.
///
/// Note : The register is defined as an i32 to be able to support the
/// different register types (`RegisterX86`, `RegisterARM`, `RegisterMIPS` etc.).
/// You need to cast the register with `as i32`.
pub fn reg_write(&self, regid: i32, value: u64) -> Result<()> {
    Self::reg_write_generic::<_>(&self, regid, value)
}

/// Write a signed 32-bit value to a register.
///
/// Note : The register is defined as an i32 to be able to support the
/// different register types (`RegisterX86`, `RegisterARM`, `RegisterMIPS` etc.).
/// You need to cast the register with `as i32`.
pub fn reg_write_i32(&self, regid: i32, value: i32) -> Result<()> {
    Self::reg_write_generic::<_>(&self, regid, value)
}
```

Many thanks for any comment.