### PR TITLE
stop hook removing when hook found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,12 +912,13 @@ impl Unicorn {
     pub fn remove_hook(&mut self, hook: uc_hook) -> Result<()> {
         let err = unsafe { uc_hook_del(self.handle, hook) } as Error;
         // Check in all maps to find which one has the hook.
-        self.code_callbacks.remove(&hook);
-        self.intr_callbacks.remove(&hook);
-        self.mem_callbacks.remove(&hook);
-        self.insn_in_callbacks.remove(&hook);
-        self.insn_out_callbacks.remove(&hook);
-        self.insn_sys_callbacks.remove(&hook);
+        macro_rules! ignore { () => { |_| () } };
+        self.code_callbacks.remove(&hook).map(ignore!())
+            .or_else(|| self.intr_callbacks.remove(&hook).map(ignore!()))
+            .or_else(|| self.mem_callbacks.remove(&hook).map(ignore!()))
+            .or_else(|| self.insn_in_callbacks.remove(&hook).map(ignore!()))
+            .or_else(|| self.insn_out_callbacks.remove(&hook).map(ignore!()))
+            .or_else(|| self.insn_sys_callbacks.remove(&hook).map(ignore!()));
 
         if err == Error::OK {
             Ok(())


### PR DESCRIPTION
The PR:
- simplifies the `fn remove_hook(&mut self, hook: uc_hook)`:  try until the hook found only
- use boxed slice for 

https://github.com/ekse/unicorn-rs/blob/4814a4f41db825c8123905006e71ffa2761a34d5/src/lib.rs#L582

IMHO, the function should return a boxed slice instead of a vector: the caller should not be able to resize the returned memory buffer.

This is a very subjective PR, then feel free to reject if you don't want it.