### PR TITLE
make `mem_read` interface more versatile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,8 +154,8 @@ pub trait Cpu {
     }
 
     /// Read a range of bytes from memory at the specified address.
-    fn mem_read(&self, address: u64, size: usize) -> Result<(Vec<u8>)> {
-        self.emu().mem_read(address, size)
+    fn mem_read(&self, address: u64, bytes: &mut [u8]) -> Result<()> {
+        self.emu().mem_read(address, bytes)
     }
 
     /// Set the memory permissions for an existing memory region.
@@ -579,21 +579,17 @@ impl Unicorn {
     }
 
     /// Read a range of bytes from memory at the specified address.
-    pub fn mem_read(&self, address: u64, size: usize) -> Result<(Vec<u8>)> {
-        let mut bytes: Vec<u8> = Vec::with_capacity(size);
+    pub fn mem_read(&self, address: u64, bytes: &mut [u8]) -> Result<()> {
         let err = unsafe {
             uc_mem_read(
                 self.handle,
                 address,
                 bytes.as_mut_ptr(),
-                size as libc::size_t,
+                bytes.len(),
             )
         };
         if err == Error::OK {
-            unsafe {
-                bytes.set_len(size);
-            }
-            Ok(bytes)
+            Ok(())
         } else {
             Err(err)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,12 @@ pub trait Cpu {
         self.emu().mem_read(address, bytes)
     }
 
+    /// Read a range of bytes from memory at the specified address; return the bytes read as a
+    /// `Vec`.
+    fn mem_read_as_vec(&self, address: u64, size: usize) -> Result<Vec<u8>> {
+        self.emu().mem_read_as_vec(address, size)
+    }
+
     /// Set the memory permissions for an existing memory region.
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
@@ -593,6 +599,16 @@ impl Unicorn {
         } else {
             Err(err)
         }
+    }
+
+    /// Read a range of bytes from memory at the specified address; return the bytes read as a
+    /// `Vec`.
+    pub fn mem_read_as_vec(&self, address: u64, size: usize) -> Result<Vec<u8>> {
+        let mut bytes: Vec<u8> = Vec::with_capacity(size);
+        unsafe { self.mem_read(address, bytes.get_unchecked_mut(0..size)) }.map(|()| unsafe {
+            bytes.set_len(size);
+            bytes
+        })
     }
 
     /// Set the memory permissions for an existing memory region.

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -152,6 +152,13 @@ pub static X86_REGISTERS: [unicorn::RegisterX86; 145] = [
     unicorn::RegisterX86::R15W,
 ];
 
+macro_rules! read_to_vec {
+    ($l:expr, $f:expr) => ({
+        let mut xs = vec![0; $l];
+        $f(&mut xs[..]).map(|()| xs)
+    })
+}
+
 #[test]
 fn emulate_x86() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
@@ -169,7 +176,7 @@ fn emulate_x86() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
-        emu.mem_read(0x1000, x86_code32.len()),
+        read_to_vec!(x86_code32.len(), |bs| emu.mem_read(0x1000, bs)),
         Ok(x86_code32.clone())
     );
 
@@ -481,7 +488,7 @@ fn emulate_arm() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &arm_code32), Ok(()));
     assert_eq!(
-        emu.mem_read(0x1000, arm_code32.len()),
+        read_to_vec!(arm_code32.len(), |bs| emu.mem_read(0x1000, bs)),
         Ok(arm_code32.clone())
     );
 
@@ -511,7 +518,7 @@ fn emulate_mips() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &mips_code32), Ok(()));
     assert_eq!(
-        emu.mem_read(0x1000, mips_code32.len()),
+        read_to_vec!(mips_code32.len(), |bs| emu.mem_read(0x1000, bs)),
         Ok(mips_code32.clone())
     );
     assert_eq!(emu.reg_write(unicorn::RegisterMIPS::AT, 0), Ok(()));
@@ -554,7 +561,7 @@ fn mem_map_ptr() {
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
-        emu.mem_read(0x1000, x86_code32.len()),
+        read_to_vec!(x86_code32.len(), |bs| emu.mem_read(0x1000, bs)),
         Ok(x86_code32.clone())
     );
 
@@ -590,7 +597,7 @@ fn mem_map_ptr() {
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
-        emu.mem_read(0x1000, x86_code32.len()),
+        read_to_vec!(x86_code32.len(), |bs| emu.mem_read(0x1000, bs)),
         Ok(x86_code32.clone())
     );
 

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -152,13 +152,6 @@ pub static X86_REGISTERS: [unicorn::RegisterX86; 145] = [
     unicorn::RegisterX86::R15W,
 ];
 
-macro_rules! read_to_vec {
-    ($l:expr, $f:expr) => ({
-        let mut xs = vec![0; $l];
-        $f(&mut xs[..]).map(|()| xs)
-    })
-}
-
 #[test]
 fn emulate_x86() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
@@ -176,7 +169,7 @@ fn emulate_x86() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
-        read_to_vec!(x86_code32.len(), |bs| emu.mem_read(0x1000, bs)),
+        emu.mem_read_as_vec(0x1000, x86_code32.len()),
         Ok(x86_code32.clone())
     );
 
@@ -488,7 +481,7 @@ fn emulate_arm() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &arm_code32), Ok(()));
     assert_eq!(
-        read_to_vec!(arm_code32.len(), |bs| emu.mem_read(0x1000, bs)),
+        emu.mem_read_as_vec(0x1000, arm_code32.len()),
         Ok(arm_code32.clone())
     );
 
@@ -518,7 +511,7 @@ fn emulate_mips() {
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &mips_code32), Ok(()));
     assert_eq!(
-        read_to_vec!(mips_code32.len(), |bs| emu.mem_read(0x1000, bs)),
+        emu.mem_read_as_vec(0x1000, mips_code32.len()),
         Ok(mips_code32.clone())
     );
     assert_eq!(emu.reg_write(unicorn::RegisterMIPS::AT, 0), Ok(()));
@@ -561,7 +554,7 @@ fn mem_map_ptr() {
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
-        read_to_vec!(x86_code32.len(), |bs| emu.mem_read(0x1000, bs)),
+        emu.mem_read_as_vec(0x1000, x86_code32.len()),
         Ok(x86_code32.clone())
     );
 
@@ -597,7 +590,7 @@ fn mem_map_ptr() {
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
     assert_eq!(
-        read_to_vec!(x86_code32.len(), |bs| emu.mem_read(0x1000, bs)),
+        emu.mem_read_as_vec(0x1000, x86_code32.len()),
         Ok(x86_code32.clone())
     );
 


### PR DESCRIPTION
#47 reminded me, i had been thinking about the `mem_read` interface...

The interface now invariably allocates, even if the caller has a buffer they could re-use. The new interface in this PR is more versatile and more closely follows `std::io`.

It's a little unfortunate we have no type to denote a potentially-uninitialized buffer; i have seen mention of a hypothetical `&out` type in other threads, a reference to potentially-uninitialized memory, which can be written but not read, but my just-woken-up self has been unable to find them this morning. If they adopt some such interface for `std::io` in future, we should also consider it here.
