### PR TITLE
[WIP] expose reg_write_generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ pub trait Cpu {
     }
 
     /// Write a generic type to a register.
-    unsafe fn reg_write_generic<T: Sized>(&self, regid: i32, value: T) -> Result<()> {
-        self.emu().reg_write_generic(regid, value)
+    unsafe fn reg_write_generic<T: Sized>(&self, reg: Self::Reg, value: T) -> Result<()> {
+        self.emu().reg_write_generic(reg.to_i32(), value)
     }
 
     /// Write an unsigned value register.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ impl Unicorn {
         }
     }
 
-    unsafe fn reg_write_generic<T: Sized>(&self, regid: i32, value: T) -> Result<()> {
+    pub unsafe fn reg_write_generic<T: Sized>(&self, regid: i32, value: T) -> Result<()> {
         let p_value: *const T = &value;
         let err = uc_reg_write(self.handle, regid, p_value as *const libc::c_void);
         if err == Error::OK {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,11 @@ pub trait Cpu {
         self.emu().reg_read_i32(reg.to_i32())
     }
 
+    /// Write a generic type to a register.
+    unsafe fn reg_write_generic<T: Sized>(&self, regid: i32, value: T) -> Result<()> {
+        self.emu().reg_write_generic(regid, value)
+    }
+
     /// Write an unsigned value register.
     fn reg_write(&self, reg: Self::Reg, value: u64) -> Result<()> {
         self.emu().reg_write(reg.to_i32(), value)
@@ -463,6 +468,10 @@ impl Unicorn {
         }
     }
 
+    /// Write a generic type to a register.
+    ///
+    /// This is required in some special cases, such as when writing `X86Mmr` to
+    /// the GDTR register in x86.
     pub unsafe fn reg_write_generic<T: Sized>(&self, regid: i32, value: T) -> Result<()> {
         let p_value: *const T = &value;
         let err = uc_reg_write(self.handle, regid, p_value as *const libc::c_void);

--- a/src/x86_const.rs
+++ b/src/x86_const.rs
@@ -270,3 +270,12 @@ pub enum InsnSysX86 {
     SYSCALL = InsnX86::SYSCALL as isize,
     SYSENTER = InsnX86::SYSENTER as isize,
 }
+
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub struct X86Mmr {
+    pub selecter: u64,
+    pub base: u64,
+    pub limit: u32,
+    pub flags: u32
+}

--- a/src/x86_const.rs
+++ b/src/x86_const.rs
@@ -252,7 +252,6 @@ pub enum RegisterX86 {
     FPTAG,
     MSR,
     MXCSR,
-    ENDING
 }
 
 #[repr(C)]

--- a/src/x86_const.rs
+++ b/src/x86_const.rs
@@ -244,6 +244,15 @@ pub enum RegisterX86 {
     R13W,
     R14W,
     R15W,
+    IDTR,
+    GDTR,
+    LDTR,
+    TR,
+    FPCW,
+    FPTAG,
+    MSR,
+    MXCSR,
+    ENDING
 }
 
 #[repr(C)]

--- a/src/x86_const.rs
+++ b/src/x86_const.rs
@@ -274,7 +274,7 @@ pub enum InsnSysX86 {
 #[repr(C)]
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub struct X86Mmr {
-    pub selecter: u64,
+    pub selector: u64,
     pub base: u64,
     pub limit: u32,
     pub flags: u32


### PR DESCRIPTION
In order to write X86Mmr to the GDTR register, we need to expose `reg_write_generic`.

This pull request builds on pull request 55 https://github.com/ekse/unicorn-rs/pull/55

For an example of what this looks like in the C API, see https://github.com/unicorn-engine/unicorn/blob/master/samples/sample_x86_32_gdt_and_seg_regs.c#L228