### PR TITLE
Explicit lifetime for unicorn handle

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,11 +11,11 @@ macro_rules! implement_register {
 macro_rules! implement_emulator {
     ($emu_type_doc:meta, $emu_instance_doc:meta, $cpu:ident, $arch:expr, $reg:ty) => {
         #[$emu_type_doc]
-        pub struct $cpu {
-            emu: Box<Unicorn>,
+        pub struct $cpu<'a> {
+            emu: Box<Unicorn<'a>>,
         }
 
-        impl $cpu {
+        impl<'a> $cpu<'a> {
             #[$emu_instance_doc]
             pub fn new(mode: Mode) -> Result<Self> {
                 let emu = Unicorn::new($arch, mode);
@@ -26,15 +26,11 @@ macro_rules! implement_emulator {
             }
         }
 
-        impl Cpu for $cpu {
+        impl<'a> Cpu<'a> for $cpu<'a> {
             type Reg = $reg;
 
-            fn emu(&self) -> &Unicorn {
+            fn emu(&self) -> &Unicorn<'a> {
                 &self.emu
-            }
-
-            fn mut_emu(&mut self) -> &mut Unicorn {
-                &mut self.emu
             }
         }
     };

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -220,17 +220,17 @@ fn emulate_x86_negative_values() {
     assert_eq!(emu.reg_read_i32(unicorn::RegisterX86::EDX), Ok(-51));
 }
 
-fn callback_lifetime_init() -> unicorn::CpuX86 {
+fn callback_lifetime_init() -> unicorn::CpuX86<'static> {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())
     );
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
-    let callback = move |uc: &unicorn::Unicorn, _: u64, _: u32| {
+    let callback = |uc: &unicorn::Unicorn, _: u64, _: u32| {
         let ecx = uc.reg_read(unicorn::RegisterX86::ECX as i32).unwrap();
         println!("ecx: {}", ecx);
     };
@@ -267,7 +267,7 @@ fn x86_code_callback() {
 
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())
@@ -299,7 +299,7 @@ fn x86_intr_callback() {
 
     let x86_code32: Vec<u8> = vec![0xcd, 0x80]; // INT 0x80;
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())
@@ -352,7 +352,7 @@ fn x86_mem_callback() {
         0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0xA3, 0x00, 0x20, 0x00, 0x00, 0xA1, 0x00, 0x00, 0x01, 0x00,
     ];
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())
@@ -392,7 +392,7 @@ fn x86_insn_in_callback() {
 
     let x86_code32: Vec<u8> = vec![0xe5, 0x10]; // IN eax, 0x10;
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())
@@ -430,7 +430,7 @@ fn x86_insn_out_callback() {
 
     let x86_code32: Vec<u8> = vec![0xb0, 0x32, 0xe6, 0x46]; // MOV al, 0x32; OUT  0x46, al;
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())
@@ -473,7 +473,7 @@ fn x86_insn_sys_callback() {
         0x48, 0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x05,
     ];
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_64).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_64).expect("failed to instantiate emulator");
     assert_eq!(
         emu.mem_map(0x1000, 0x4000, unicorn::Protection::ALL),
         Ok(())


### PR DESCRIPTION
Hello all,

IMHO, there are two problems with the current design

#### Lifetime of "opaque handle" 

The struct https://github.com/ekse/unicorn-rs/blob/800374d8b33fbf810b06b86b561944b03de85789/src/lib.rs#L411-L420

is a wrapper for the raw `uc_engine` so the lifetime of `handle` should not beyond one of its `Unicorn` instance (and not vice-versa). One way to do that is using a phantom field:

```Rust
pub struct Unicorn<'a> {
    handle: libc::size_t, // Opaque handle to uc_engine
    ...
    phantom: PhantomData<&'a libc::size_t>,
}
```

Consequently, for a hook, e.g. https://github.com/ekse/unicorn-rs/blob/800374d8b33fbf810b06b86b561944b03de85789/src/lib.rs#L404

the lifetime of the calback `FnMut(&Unicorn, u32)` needn't to be `'static`, indeed `'a` is enough*:  the benefit of this is to allow the callback to access/modify anything whose [lifetime larger than `'a` but not necessary `'static`](https://morestina.net/blog/793/closure-lifetimes-in-rust)

```Rust
type CodeHook<'a> = UnicornHook<'a, Box<'a + FnMut(&Unicorn, u64, u32)>>;
```

More correctly, the reference passed in to `FnMut` should have lifetime at least `'a` , this hook should be

```Rust
type CodeHook<'a> = UnicornHook<'a, Box<'a + FnMut(&'a Unicorn<'a>, u64, u32)>>;
```
It is redundant though, because there is no way to pass a reference of a smaller lifetime to the callback in current design: it is done in the "C side" of FFI boundary.

#### Mutability of "Unicorn"

Because the needs of add/remove hooks, `Unicorn` is used as mutable in some context, e.g. https://github.com/ekse/unicorn-rs/blob/800374d8b33fbf810b06b86b561944b03de85789/src/lib.rs#L701-L708

But using `&mut sef` is "unsafe", let's look at

https://github.com/ekse/unicorn-rs/blob/800374d8b33fbf810b06b86b561944b03de85789/src/lib.rs#L715-L718

Using `unicorn: self as *mut _` here,  `self` is supposed to be always valid, unfortunately this constraint isn't warranted by the compiler because it is passed as `&mut self`. But passing it as `&self` is not possible since the callback list needs to be updated https://github.com/ekse/unicorn-rs/blob/800374d8b33fbf810b06b86b561944b03de85789/src/lib.rs#L733-L736 

Though this update cannot make `self` to be relocated (it is possible for `code_callback`), we cannot get this fact by profiting from the compiler check. One way to do that is use _interior mutability_ for the lists of callbacks

```Rust
pub struct Unicorn<'a> {
    handle: libc::size_t, // Opaque handle to uc_engine
    code_callbacks: RefCell<HashMap<uc_hook, Box<CodeHook<'a>>>>,
    intr_callbacks: RefCell<HashMap<uc_hook, Box<IntrHook<'a>>>>,
    mem_callbacks: RefCell<HashMap<uc_hook, Box<MemHook<'a>>>>,
    insn_in_callbacks: RefCell<HashMap<uc_hook, Box<InsnInHook<'a>>>>,
    insn_out_callbacks: RefCell<HashMap<uc_hook, Box<InsnOutHook<'a>>>>,
    insn_sys_callbacks: RefCell<HashMap<uc_hook, Box<InsnSysHook<'a>>>>,
    phantom: PhantomData<&'a libc::size_t>,
}
```
so we can pass `self` as immutability for all methods of `Unicorn` and `CpuXXX` (then there is no need for `mut_emu`).

The PR does these changes. Thanks a lot for any comment.