### PR TITLE
use mem::MaybeUninit::uninit() instead of the obsolete mem::zeroed()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,15 +501,14 @@ impl<'a> Unicorn<'a> {
     }
 
     unsafe fn reg_read_generic<T: Sized>(&self, regid: i32) -> Result<T> {
-        // deprecating in Rust 2.0.0: use mem::MaybeUninit::zeroed() instead
-        let mut value: T = mem::zeroed();
+        let mut value = mem::MaybeUninit::<T>::uninit();
         let err = uc_reg_read(
             self.handle,
             regid as libc::c_int,
             &mut value as *mut _ as *mut libc::c_void,
         );
         if err == Error::OK {
-            Ok(value)
+            Ok(value.assume_init())
         } else {
             Err(err)
         }


### PR DESCRIPTION
This PR replaces the current: https://github.com/ekse/unicorn-rs/blob/6aca2c329c4d221c655f111e06a71720b778b8e5/src/lib.rs#L503-L505

by

```Rust
unsafe fn reg_read_generic<T: Sized>(&self, regid: i32) -> Result<T> {
    let mut value = mem::MaybeUninit::<T>::uninit();
```

because of this [scary](https://gankro.github.io/blah/initialize-me-maybe/) phrase:

> And to be absolutely clear, it's not obvious [..] that mem::uninitialized is usable even for always-valid types like u32.... So even if you're very confident [...] you should still use MaybeUninit just to be safe.

We should wait for the landing of next stable Rust release though.